### PR TITLE
feat: add update booking details and api spec

### DIFF
--- a/api-spec.yaml
+++ b/api-spec.yaml
@@ -460,6 +460,58 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /users/{userId}/books/{isbn}/details:
+    put:
+      summary: Bearbeite Buchinformationen manuell
+      description: |
+        Erlaubt Benutzern, bestimmte Felder eines Buches zu bearbeiten (Titel, Autoren, Beschreibung, Cover-URL).
+      parameters:
+        - name: userId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: isbn
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title:
+                  type: string
+                authors:
+                  type: array
+                  items:
+                    type: string
+                description:
+                  type: string
+                coverUrl:
+                  type: string
+      responses:
+        "200":
+          description: Buch erfolgreich aktualisiert
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Book"
+        "400":
+          description: Ungültige Felder
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "404":
+          description: Buch oder Benutzer nicht gefunden
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
   /users/{userId}/books/{isbn}/reviews:
     get:
       summary: Alle Rezensionen eines Buches

--- a/src/main/java/at/fhburgenland/bookmanager/controller/BookController.java
+++ b/src/main/java/at/fhburgenland/bookmanager/controller/BookController.java
@@ -1,6 +1,7 @@
 // src/main/java/at/fhburgenland/bookmanager/controller/BookController.java
 package at.fhburgenland.bookmanager.controller;
 
+import at.fhburgenland.bookmanager.dto.BookUpdateRequest;
 import at.fhburgenland.bookmanager.dto.IsbnRequest;
 import at.fhburgenland.bookmanager.dto.RatingUpdateRequest;
 import at.fhburgenland.bookmanager.model.Book;
@@ -59,6 +60,25 @@ public class BookController {
         Book updated = bookService.updateBookRating(userId, isbn, request.getRating());
         return ResponseEntity.ok(updated);
     }
+
+    /**
+     * Aktualisiert bestimmte Buchinformationen wie Titel, Autoren, Beschreibung oder Cover-URL.
+     *
+     * @param userId Benutzer-ID
+     * @param isbn   ISBN des Buchs
+     * @param request Felder, die aktualisiert werden sollen
+     * @return Das aktualisierte Buch
+     */
+    @PutMapping("/{isbn}/details")
+    public ResponseEntity<Book> updateBookDetails(
+            @PathVariable UUID userId,
+            @PathVariable String isbn,
+            @Valid @RequestBody BookUpdateRequest request
+    ) {
+        Book updated = bookService.updateBookDetails(userId, isbn, request);
+        return ResponseEntity.ok(updated);
+    }
+
 
     /**
      * Liefert die vollständigen Details eines Buches für einen bestimmten Benutzer.

--- a/src/main/java/at/fhburgenland/bookmanager/dto/BookUpdateRequest.java
+++ b/src/main/java/at/fhburgenland/bookmanager/dto/BookUpdateRequest.java
@@ -1,0 +1,20 @@
+package at.fhburgenland.bookmanager.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class BookUpdateRequest {
+    @Size(max = 255)
+    private String title;
+
+    private List<String> authors;
+
+    @Size(max = 5000)
+    private String description;
+
+    @Size(max = 2048)
+    private String coverUrl;
+}

--- a/src/main/java/at/fhburgenland/bookmanager/service/BookService.java
+++ b/src/main/java/at/fhburgenland/bookmanager/service/BookService.java
@@ -1,5 +1,6 @@
 package at.fhburgenland.bookmanager.service;
 
+import at.fhburgenland.bookmanager.dto.BookUpdateRequest;
 import at.fhburgenland.bookmanager.exception.BookNotFoundException;
 import at.fhburgenland.bookmanager.exception.InvalidBookException;
 import at.fhburgenland.bookmanager.exception.UserNotFoundException;
@@ -219,6 +220,24 @@ public class BookService {
                 .filter(book -> author == null || book.getAuthors() != null && book.getAuthors().stream().anyMatch(a -> a.toLowerCase().contains(author.toLowerCase())))
                 .filter(book -> year == null || (book.getPublishedDate() != null && book.getPublishedDate().contains(year.toString())))
                 .toList();
+    }
+
+    public Book updateBookDetails(UUID userId, String isbn, BookUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        Book book = user.getBooks().stream()
+                .filter(b -> b.getIsbn().equalsIgnoreCase(isbn))
+                .findFirst()
+                .orElseThrow(() -> new BookNotFoundException(isbn));
+
+        // Nur erlaubte Felder überschreiben
+        if (request.getTitle() != null) book.setTitle(request.getTitle());
+        if (request.getAuthors() != null) book.setAuthors(request.getAuthors());
+        if (request.getDescription() != null) book.setDescription(request.getDescription());
+        if (request.getCoverUrl() != null) book.setCoverUrl(request.getCoverUrl());
+
+        return bookRepository.save(book);
     }
 
 }

--- a/src/test/java/at/fhburgenland/bookmanager/controller/BookControllerTest.java
+++ b/src/test/java/at/fhburgenland/bookmanager/controller/BookControllerTest.java
@@ -132,6 +132,34 @@ class BookControllerTest {
     }
 
     @Test
+    void updateBookDetails_ValidRequest_ReturnsUpdatedBook() throws Exception {
+        String isbn = "123";
+        Book book = Book.builder()
+                .isbn(isbn)
+                .title("Updated")
+                .description("Updated desc")
+                .user(testUser)
+                .build();
+        testUser.getBooks().add(book);
+        userRepository.save(testUser);
+
+        String json = """
+    {
+      "title": "Neuer Titel",
+      "description": "Neue Beschreibung",
+      "coverUrl": "https://neu"
+    }
+    """;
+
+        mockMvc.perform(put("/users/{userId}/books/{isbn}/details", testUser.getId(), isbn)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Neuer Titel"))
+                .andExpect(jsonPath("$.description").value("Neue Beschreibung"));
+    }
+
+    @Test
     void deleteBook_ExistingBook_ReturnsNoContent() throws Exception {
         String isbn = "9780140328721";
         Book book = Book.builder()

--- a/src/test/java/at/fhburgenland/bookmanager/e2e/BookE2ETest.java
+++ b/src/test/java/at/fhburgenland/bookmanager/e2e/BookE2ETest.java
@@ -368,4 +368,41 @@ class BookE2ETest {
         }
     }
 
+    @Test
+    void updateBook_DetailsValid_ReturnsUpdatedBook() throws Exception {
+        Book book = Book.builder()
+                .isbn("1234567890")
+                .title("Alt")
+                .description("Original")
+                .coverUrl("oldUrl")
+                .user(testUser)
+                .build();
+        testUser.getBooks().add(book);
+        userRepository.save(testUser);
+
+        String json = """
+    {
+      "title": "Neuer Titel",
+      "description": "Neue Beschreibung",
+      "coverUrl": "https://neu"
+    }
+    """;
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<String> entity = new HttpEntity<>(json, headers);
+
+        ResponseEntity<Book> response = restTemplate.exchange(
+                getUrl("/users/" + testUser.getId() + "/books/1234567890/details"),
+                HttpMethod.PUT,
+                entity,
+                Book.class
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().getTitle()).isEqualTo("Neuer Titel");
+        assertThat(response.getBody().getDescription()).isEqualTo("Neue Beschreibung");
+        assertThat(response.getBody().getCoverUrl()).isEqualTo("https://neu");
+    }
 }

--- a/src/test/java/at/fhburgenland/bookmanager/integration/BookIntegrationTest.java
+++ b/src/test/java/at/fhburgenland/bookmanager/integration/BookIntegrationTest.java
@@ -304,4 +304,33 @@ class BookIntegrationTest {
                 .andExpect(jsonPath("$.length()").value(2));
     }
 
+    @Test
+    void updateBook_DetailsOnlyCertainFieldsAreUpdated() throws Exception {
+        String isbn = "1234567890";
+        Book book = Book.builder()
+                .isbn(isbn)
+                .title("Original Title")
+                .description("Old Desc")
+                .coverUrl("old-url.jpg")
+                .user(testUser)
+                .build();
+
+        testUser.getBooks().add(book);
+        userRepository.save(testUser);
+
+        String json = """
+    {
+      "title": "Updated Title",
+      "coverUrl": "https://updated"
+    }
+    """;
+
+        mockMvc.perform(put("/users/" + testUser.getId() + "/books/" + isbn + "/details")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.title").value("Updated Title"))
+                .andExpect(jsonPath("$.coverUrl").value("https://updated"))
+                .andExpect(jsonPath("$.description").value("Old Desc"));
+    }
 }

--- a/src/test/java/at/fhburgenland/bookmanager/service/BookServiceTest.java
+++ b/src/test/java/at/fhburgenland/bookmanager/service/BookServiceTest.java
@@ -1,5 +1,6 @@
 package at.fhburgenland.bookmanager.service;
 
+import at.fhburgenland.bookmanager.dto.BookUpdateRequest;
 import at.fhburgenland.bookmanager.exception.BookNotFoundException;
 import at.fhburgenland.bookmanager.exception.InvalidBookException;
 import at.fhburgenland.bookmanager.exception.UserNotFoundException;
@@ -189,6 +190,32 @@ class BookServiceTest {
             bookService.updateBookRating(userId, "notfound", 4);
         });
     }
+
+    @Test
+    void updateBookDetails_ValidFields_UpdatesOnlyProvidedFields() {
+        Book book = Book.builder()
+                .isbn("123")
+                .title("Alt")
+                .description("Alt Desc")
+                .coverUrl("oldUrl")
+                .user(mockUser)
+                .build();
+
+        mockUser.getBooks().add(book);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(bookRepository.save(any(Book.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        BookUpdateRequest request = new BookUpdateRequest();
+        request.setTitle("Neu");
+        request.setCoverUrl("https://neu");
+
+        Book result = bookService.updateBookDetails(userId, "123", request);
+
+        assertThat(result.getTitle()).isEqualTo("Neu");
+        assertThat(result.getCoverUrl()).isEqualTo("https://neu");
+        assertThat(result.getDescription()).isEqualTo("Alt Desc"); // nicht verändert
+    }
+
 
     @Test
     void deleteBookByUserIdAndIsbn_BookExists_DeletesSuccessfully() {


### PR DESCRIPTION
add manually update of booking details like title, authors (Everything else, except rating) and update api spec

closes #14